### PR TITLE
Call Python 3 with the python3 command

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-python platform_config.py
+python3 platform_config.py
 gcc -c ./cli/tty_ifo.c
 gcc -c *.c
 gnatmake -j0 -I./cli/ -I./hex/ -I./unicode -I./modular_hashing aura.adb


### PR DESCRIPTION
On some platforms the "python" command doesn't exist by default
(Ubuntu 20.04, OpenBSD), on others it runs Python 2 (macOS).  However,
on all of them the command python3 runs a Python 3 interpreter.

I know the installation documentation says to make sure that "python"
points at a Python 3 interpreter, but using python3 seems less likely
to fail.