### PR TITLE
Fix build on OpenBSD

### DIFF
--- a/child_processes-platform-binding.c
+++ b/child_processes-platform-binding.c
@@ -77,9 +77,11 @@
 /*   Convention    => C,                                   */
 /*   External_Name => "__chldproc_platform_fork_and_exec"; */
 
+/* The names stdinput, stdoutput, and stderror below avoid */
+/* colliding with macros on OpenBSD.                       */
 extern int __chldproc_platform_fork_and_exec
 (char  * path, char ** args, char * wdir,
- pid_t * pid,  int  * stdin, int  * stdout, int * stderr)
+ pid_t * pid,  int  * stdinput, int  * stdoutput, int * stderror)
 {
      pid_t event_horizon;
      
@@ -115,21 +117,21 @@ extern int __chldproc_platform_fork_and_exec
           *pid = event_horizon;
           
           /* Child's stdin, so we take the write-end     */
-          *stdin  = stdin_pipe[WRITE_END];
+          *stdinput  = stdin_pipe[WRITE_END];
 
           /* Child's stdout/err, so we take the read-end */
-          *stdout = stdout_pipe[READ_END];
-          *stderr = stderr_pipe[READ_END];
+          *stdoutput = stdout_pipe[READ_END];
+          *stderror = stderr_pipe[READ_END];
 
           /* Set non-blocking on the read pipes */
-          modflags = fcntl ( *stdin, F_GETFL );
-          fcntl ( *stdin, F_SETFL, modflags | O_NONBLOCK );
+          modflags = fcntl ( *stdinput, F_GETFL );
+          fcntl ( *stdinput, F_SETFL, modflags | O_NONBLOCK );
           
-          modflags = fcntl ( *stdout, F_GETFL );
-          fcntl ( *stdout, F_SETFL, modflags | O_NONBLOCK );
+          modflags = fcntl ( *stdoutput, F_GETFL );
+          fcntl ( *stdoutput, F_SETFL, modflags | O_NONBLOCK );
 
-          modflags = fcntl ( *stderr, F_GETFL );
-          fcntl ( *stderr, F_SETFL, modflags | O_NONBLOCK );
+          modflags = fcntl ( *stderror, F_GETFL );
+          fcntl ( *stderror, F_SETFL, modflags | O_NONBLOCK );
 
           return (0);
      }


### PR DESCRIPTION
On OpenBSD (and maybe elsewhere?), stdio.h has the following macros:

    #define stdin   (&__sF[0])
    #define stdout  (&__sF[1])
    #define stderr  (&__sF[2])

which causes the following compilation errors on
child_processes-platform-binding.c:

    In file included from child_processes-platform-binding.c:49:
    child_processes-platform-binding.c:82:23: error: expected ')' before
    '&' token
       82 |  pid_t * pid,  int  * stdin, int  * stdout, int * stderr)
          |                       ^~~~~
    child_processes-platform-binding.c:82:30: error: expected ';', ',' or
    ')' before 'int'
       82 |  pid_t * pid,  int  * stdin, int  * stdout, int * stderr)
          |                              ^~~

This commit renames {stdin,stdout,stderr} to
{stdinput,stdoutput,stderror} to avoid colliding with the macros.  The
names I chose aren't great, but they work and I don't have a better
idea.